### PR TITLE
Update jest config to pick test files in node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .nyc_output
+.vscode/
 coverage/
 dist
 node_modules/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   collectCoverage: false,
   testEnvironment: "node",
-  roots: ["src"]
+  roots: ["src"],
+  haste: {
+    "providesModuleNodeModules": [".*"]
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,7 @@ const run = () => {
   const options = {
     roots: ["__checks__"],
     verbose: true,
-    // silent: true,
-    // showConfig: true,
-    // noStackTrace: true,
-    // useStderr: true,
-    // json:true,
+    testPathIgnorePatterns: []
   };
   jest.runCLI(options, [__dirname], () => {});
 };


### PR DESCRIPTION
Fixes #4 

## Description
As identified by @pgoldrbx the issue was with Haste ignoring any code in `node_modules`.
This issue has been extensively discussed [here](https://github.com/facebook/jest/issues/2145) and a fix is to update the jest config for haste to allow all dirs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
#4 

## Motivation and Context
The tool doesnt work as a command line utility without this fix :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
Manually tested for a few projects.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
