### PR TITLE
Release/v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [x.y.z]: https://github.com/CondeNast/opensource-check/compare/1.0.0...x.y.z
 -->
+## 0.0.5 - 2021-05-24
+- Run opensource-check on opensource-check (#15)
+- Fix security warnings (#16)
 
 ## 0.0.4 - 2018-06-06
 - Update how we gather command line args

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@condenast/opensource-check",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@condenast/opensource-check",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Test Runner for Open Source Conventions",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Packages that use this package as a dependency get security warnings that originate from this package's sub dependencies for v0.0.4; These security issues have been addressed but still need to be released/published to npm.
